### PR TITLE
mvn install -DskipTests时报错：java.lang.NoClassDefFoundError: org/sonatype/aether/version/VersionConstraint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.0</version>
+                <version>2.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
将maven-shade-plugin版本由2.0升级为2.1问题解决，链接：https://cwiki.apache.org/confluence/display/MAVEN/AetherClassNotFound
